### PR TITLE
Implement `ones` using `trailing_zeros`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,13 +70,14 @@ impl FixedBitSet
             length: bits,
         }
     }
+
     /// Create a new **FixedBitSet** with a specific number of bits,
     /// initialized from provided blocks.
     ///
     /// If the blocks are not the exact size needed for the capacity
     /// they will be padded with zeros (if shorter) or truncated to
     /// the capacity (if longer).
-    /// 
+    ///
     /// For example:
     /// ```
     /// let data = vec![4];


### PR DESCRIPTION
The `iter_ones_all_zeros` benchmark improved a lot, the results for `iter_ones_all_ones` are too noisy on my machine to tell. Will update when I have better numbers.

Fixes #17.