### PR TITLE
adding toggle function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ impl FixedBitSet
             length: bits,
         }
     }
-    
     /// Grow capacity to **bits**, all new bits initialized to zero
     pub fn grow(&mut self, bits: usize) {
         let (mut blocks, rem) = div_rem(bits, BITS);
@@ -113,7 +112,16 @@ impl FixedBitSet
             prev
         }
     }
-
+    /// ***Panics** if **bit** is out of bounds
+    /// toggle the bit (inverting its state)
+    #[inline]
+    pub fn toggle(&mut self, bit: usize) {
+        assert!(bit < self.length);
+        let (block, i) = div_rem(bit, BITS);
+        unsafe {
+            *self.data.get_unchecked_mut(block) ^= (1 << i);
+        }
+    }
     /// **Panics** if **bit** is out of bounds.
     #[inline]
     pub fn set(&mut self, bit: usize, enabled: bool)


### PR DESCRIPTION
hi,
this is a simple pull request where I added a function toggle: this function allow to inverting bit's state.
the `toggle`'s prototype is the following: `fn toggle(&mut self, bit: usize);` 
# usage
there's an example usage:
```Rust
pub fn toggle_cell(&mut self, row: u32, col: u32) {
        let idx = self.get_index(row, col);
        self.cells.toggle(idx);
    }
```