### PR TITLE
Add default feature "std", which if disabled makes the library no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,25 @@ language: rust
 sudo: false
 matrix:
   include:
+    - rust: 1.31.1
+    - rust: 1.36.0
+      env:
+      - TEST_NOSTD=1
     - rust: stable
+      env:
+      - TEST_NOSTD=1
     - rust: beta
-    - rust: nightly
+      env:
+      - TEST_NOSTD=1
     - rust: nightly
       env:
-      - FEATURES='no_std'
+      - TEST_NOSTD=1
 branches:
   only:
     - master
 script:
   - |
+      ( [ -z "$TEST_NOSTD" ] || cargo test -v --no-default-features --tests --lib) &&
       cargo build --verbose --features "$FEATURES" &&
       cargo test --verbose --features "$FEATURES" &&
       cargo test --verbose --release --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ categories = ["data-structures"]
 no-dev-version = true
 
 [features]
-no_std = []
+std = []
+default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,17 @@
 //! `FixedBitSet` is a simple fixed size set of bits.
 #![doc(html_root_url="https://docs.rs/fixedbitset/0.1/")]
 
-#![cfg_attr(feature = "no_std", feature(alloc))]
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::{
     vec,
     vec::Vec,
 };
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use core as std;
 
 mod range;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,16 @@
 //! `FixedBitSet` is a simple fixed size set of bits.
+//!
+//!
+//! ### Crate features
+//!
+//! - `std` (default feature)  
+//!   Disabling this feature disables using std and instead uses crate alloc.
+//!   Requires Rust 1.36 to disable.
+//!
+//! ### Rust Version
+//!
+//! This version of fixedbitset requires Rust 1.31 or later.
+//!
 #![doc(html_root_url="https://docs.rs/fixedbitset/0.1/")]
 
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
I'm putting the min Rust version at Rust 1.31 (introduction of 2018 edition) since we don't need more.

Using alloc requires Rust 1.36.0, so that's a requirement specifically for using the non-default configuration.

Follows up on #31 