### PR TITLE
Add in-place difference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,14 @@ impl FixedBitSet
         }
     }
 
+    /// In-place difference between two `FixedBitSet`s.
+    pub fn difference_with(&mut self, other: &FixedBitSet)
+    {
+        for (x, y) in self.data.iter_mut().zip(other.data.iter()) {
+            *x &= !*y;
+        }
+    }
+
     /// In-place symmetric difference of two `FixedBitSet`s.
     pub fn symmetric_difference_with(&mut self, other: &FixedBitSet)
     {


### PR DESCRIPTION
This completes the pairs of iterators/in-place methods for each of: union, intersection, difference, symmetric difference.

Bounds checking: S &minus; T will never include elements that weren't already in S, so S doesn't need to grow.