### PR TITLE
Add `toggle_range`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl FixedBitSet
 
     /// Sets every bit in the given range to the given state (`enabled`)
     ///
-    /// Use `..` to toggle the whole bitset.
+    /// Use `..` to set the whole bitset.
     ///
     /// **Panics** if the range extends past the end of the bitset.
     #[inline]
@@ -224,6 +224,21 @@ impl FixedBitSet
     pub fn insert_range<T: IndexRange>(&mut self, range: T)
     {
         self.set_range(range, true);
+    }
+
+    /// Toggles (inverts) every bit in the given range.
+    ///
+    /// Use `..` to toggle the whole bitset.
+    ///
+    /// **Panics** if the range extends past the end of the bitset.
+    #[inline]
+    pub fn toggle_range<T: IndexRange>(&mut self, range: T)
+    {
+        for (block, mask) in Masks::new(range, self.length) {
+            unsafe {
+                *self.data.get_unchecked_mut(block) ^= mask;
+            }
+        }
     }
 
     /// View the bitset as a slice of `u32` blocks
@@ -882,6 +897,22 @@ fn set_range() {
         assert_eq!(fb.contains(i), 5<=i&&i<9 || 32<=i&&i<37);
     }
     assert!(!fb.contains(48));
+    assert!(!fb.contains(64));
+}
+
+#[test]
+fn toggle_range() {
+    let mut fb = FixedBitSet::with_capacity(40);
+    fb.insert_range(..10);
+    fb.insert_range(34..38);
+
+    fb.toggle_range(5..12);
+    fb.toggle_range(30..);
+
+    for i in 0..40 {
+        assert_eq!(fb.contains(i), i<5 || 10<=i&&i<12 || 30<=i&&i<34 || 38<=i);
+    }
+    assert!(!fb.contains(40));
     assert!(!fb.contains(64));
 }
 


### PR DESCRIPTION
Without this it's hard to invert an entire bitset.

Bounds checking: The only set bits after `fb.toggle_range(_)` will be those originally set in `fb`, or those appearing in `mask`. Keeping set bits doesn't change the size of the set; and all `mask` bits are in bounds by definition.