### PR TITLE
New constructor with blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,16 @@ impl FixedBitSet
         }
     }
     /// Create a new **FixedBitSet** with a specific number of bits,
-    /// all initially clear.
-    pub fn with_capacity_and_blocks(bits: usize, data: Vec<Block>) -> Self
+    /// initialized from provided blocks.
+    ///
+    /// This will panic if the blocks are not the exact size needed
+    /// for the capacity.
+    pub fn with_capacity_and_blocks<I: IntoIterator<Item=Block>>(bits: usize, blocks: I) -> Self
     {
-        let (mut blocks, rem) = div_rem(bits, BITS);
-        blocks += (rem > 0) as usize;
-        assert_eq!(blocks, data.len());
+        let (mut n_blocks, rem) = div_rem(bits, BITS);
+        n_blocks += (rem > 0) as usize;
+        let data: Vec<Block> = blocks.into_iter().collect();
+        assert_eq!(n_blocks, data.len());
         FixedBitSet {
             data: data,
             length: bits,
@@ -723,6 +727,18 @@ fn with_blocks() {
 
     let ones: Vec<_> = fb.ones().collect();
     assert!(fb.contains(3));
+}
+
+#[should_panic]
+#[test]
+fn with_blocks_too_small() {
+    let fb = FixedBitSet::with_capacity_and_blocks(500, vec![8u32, 0u32]);
+}
+
+#[should_panic]
+#[test]
+fn with_blocks_too_big() {
+    let fb = FixedBitSet::with_capacity_and_blocks(1, vec![8u32, 24u32]);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,18 @@ impl FixedBitSet
             length: bits,
         }
     }
+    /// Create a new **FixedBitSet** with a specific number of bits,
+    /// all initially clear.
+    pub fn with_capacity_and_blocks(bits: usize, data: Vec<Block>) -> Self
+    {
+        let (mut blocks, rem) = div_rem(bits, BITS);
+        blocks += (rem > 0) as usize;
+        assert_eq!(blocks, data.len());
+        FixedBitSet {
+            data: data,
+            length: bits,
+        }
+    }
     /// Grow capacity to **bits**, all new bits initialized to zero
     pub fn grow(&mut self, bits: usize) {
         let (mut blocks, rem) = div_rem(bits, BITS);
@@ -703,6 +715,14 @@ fn it_works() {
     }
 
     fb.clear();
+}
+
+#[test]
+fn with_blocks() {
+    let fb = FixedBitSet::with_capacity_and_blocks(50, vec![8u32, 0u32]);
+
+    let ones: Vec<_> = fb.ones().collect();
+    assert!(fb.contains(3));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a new constructor taking `capacity` and `blocks`. I needed this because loading big bitsets using `.from_iter` or `.extend` was slow, and with this change it is much faster because it avoids all the conversions to find what bit to set. (Incidentally, if anyone has good approaches to load data from disk that avoids this PR, I'm interested).

I really like all the other features in fixedbitset, and didn't want to lose them by switching to another crate... But I also understand that this is an invasive change, because it exposes internals and makes it harder to change how data is stored or accessed in the future.

Additional changes: maybe make the signature `pub unsafe fn with_capacity_and_blocks(bits: usize, data: Vec<Block>) -> Self` to indicate the caller is responsible for passing `Vec<block>` in the right format?