### PR TITLE
Implement custom behavior for PartialEq, Eq, PartialOrd, Ord and Hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1599,7 +1599,9 @@ fn display_trait() {
 fn comparison_and_hash() {
     fn with_values(values: &[usize], capacity: usize) -> FixedBitSet {
         let mut r = FixedBitSet::with_capacity(capacity);
-        r.extend(values.iter().copied());
+        for &v in values {
+            r.put(v);
+        }
         r
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1605,10 +1605,23 @@ fn comparison_and_hash() {
         r
     }
 
-    fn hash_of<T: Hash>(t: &T) -> u64 {
-        let mut s = std::collections::hash_map::DefaultHasher::new();
+    #[derive(Default)]
+    struct MockHasher {
+        bytes: Vec<u8>
+    }
+    impl Hasher for MockHasher {
+        fn finish(&self) -> u64 {
+            unimplemented!()
+        }
+        fn write(&mut self, bytes: &[u8]) {
+            self.bytes.extend_from_slice(bytes);
+        }
+    }
+
+    fn hash_of<T: Hash>(t: &T) -> Vec<u8> {
+        let mut s = MockHasher::default();
         t.hash(&mut s);
-        s.finish()
+        s.bytes
     }
 
     let single_7_17 = with_values(&[7, 17], 32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, I
 use std::cmp::{Ord, Ordering};
 use std::iter::{Chain, FromIterator};
 pub use range::IndexRange;
+use std::hash::{Hash, Hasher};
 
 const BITS: usize = 32;
 type Block = u32;
@@ -50,7 +51,7 @@ fn div_rem(x: usize, d: usize) -> (usize, usize)
 ///
 /// The bit set has a fixed capacity in terms of enabling bits (and the
 /// capacity can grow using the `grow` method).
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, Default)]
 pub struct FixedBitSet {
     data: Vec<Block>,
     /// length in bits
@@ -767,6 +768,43 @@ impl <'a> BitXorAssign for FixedBitSet
 {
     fn bitxor_assign(&mut self, other: Self) {
         self.symmetric_difference_with(&other);
+    }
+}
+
+/// Two `FixedBitSet`s are equal if and only if they have the exact same set of "one" elements
+impl PartialEq for FixedBitSet
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.ones().eq(other.ones())
+    }
+}
+
+impl Eq for FixedBitSet {}
+
+impl PartialOrd for FixedBitSet
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FixedBitSet
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ones().cmp(other.ones())
+    }
+}
+
+impl Hash for FixedBitSet
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for elt in self.ones() {
+            elt.hash(state);
+        }
     }
 }
 
@@ -1555,4 +1593,41 @@ fn display_trait() {
 
     assert_eq!(format!("{}", fb), "00101000");
     assert_eq!(format!("{:#}", fb), "0b00101000");
+}
+
+#[test]
+fn comparison_and_hash() {
+    fn with_values(values: &[usize], capacity: usize) -> FixedBitSet {
+        let mut r = FixedBitSet::with_capacity(capacity);
+        r.extend(values.iter().copied());
+        r
+    }
+
+    fn hash_of<T: Hash>(t: &T) -> u64 {
+        let mut s = std::collections::hash_map::DefaultHasher::new();
+        t.hash(&mut s);
+        s.finish()
+    }
+
+    let single_7_17 = with_values(&[7, 17], 32);
+    let single_7_10 = with_values(&[7, 10], 32);
+    let single_7_20 = with_values(&[7, 20], 32);
+    let double_7_17 = with_values(&[7, 17], 64);
+    let double_7_17_37 = with_values(&[7, 17, 37], 64);
+
+    // Equality
+    assert_eq!(single_7_17, double_7_17);
+    assert_ne!(single_7_17, single_7_10);
+    assert_ne!(double_7_17, double_7_17_37);
+
+    // Comparison
+    assert_eq!(single_7_17.cmp(&double_7_17), Ordering::Equal);
+    assert_eq!(single_7_17.cmp(&single_7_10), Ordering::Greater);
+    assert_eq!(single_7_17.cmp(&single_7_20), Ordering::Less);
+    assert_eq!(single_7_17.cmp(&double_7_17_37), Ordering::Less);
+
+    // Hash
+    assert_eq!(hash_of(&single_7_17), hash_of(&double_7_17));
+    assert_ne!(hash_of(&single_7_17), hash_of(&single_7_10));
+    assert_ne!(hash_of(&double_7_17), hash_of(&double_7_17_37));
 }


### PR DESCRIPTION
Hi,

Following up on https://github.com/petgraph/fixedbitset/issues/44, here is my take on implementing `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`. This PR goes beyond the scope of the issue, so all those related traits would be in sync.

This is a behavior change that, in practice, makes `FixedBitSet` behave like a `BTreeSet<usize>`, whose elements are the items returned by `FixedBitSet::ones()`. The change can be breaking for some pieces of code that depended on the old behavior, even if it was undocumented and arguably surprising.

For example, using `FixedBitSet` in map will behave differently:

```rust
let mut map = HashMap::new();
map.insert(FixedBitSet::with_capacity(0), 17);
map.insert(FixedBitSet::with_capacity(10), 17);
dbg!(map.len()); // before = 2, now = 1
```

Fix #44 

Please tell me what you think,
Best regards,