### PR TITLE
Add is_clear method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ fn div_rem(x: usize, d: usize) -> (usize, usize) {
 ///
 /// The bit set has a fixed capacity in terms of enabling bits (and the
 /// capacity can grow using the `grow` method).
-/// 
+///
 /// Derived traits depend on both the zeros and ones, so [0,1] is not equal to
 /// [0,1,0].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -122,16 +122,59 @@ impl FixedBitSet {
         }
     }
 
-    /// Return the length of the [`FixedBitSet`] in bits.
+    /// The length of the [`FixedBitSet`] in bits.
+    ///
+    /// Note: `len` includes both set and unset bits.
+    /// ```
+    /// # use fixedbitset::FixedBitSet;
+    /// let bitset = FixedBitSet::with_capacity(10);
+    /// // there are 0 set bits, but 10 unset bits
+    /// assert_eq!(bitset.len(), 10);
+    /// ```
+    /// `len` does not return the count of set bits. For that, use
+    /// [`bitset.count_ones(..)`](FixedBitSet::count_ones) instead.
     #[inline]
     pub fn len(&self) -> usize {
         self.length
     }
 
-    /// Return if the [`FixedBitSet`] is empty.
+    /// `true` if the [`FixedBitSet`] is empty.
+    ///
+    /// Note that an "empty" `FixedBitSet` is a `FixedBitSet` with
+    /// no bits (meaning: it's length is zero). If you want to check
+    /// if all bits are unset, use [`FixedBitSet::is_clear`].
+    ///
+    /// ```
+    /// # use fixedbitset::FixedBitSet;
+    /// let bitset = FixedBitSet::with_capacity(10);
+    /// assert!(!bitset.is_empty());
+    ///
+    /// let bitset = FixedBitSet::with_capacity(0);
+    /// assert!(bitset.is_empty());
+    /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// `true` if all bits in the [`FixedBitSet`] are unset.
+    ///
+    /// As opposed to [`FixedBitSet::is_empty`], which is `true` only for
+    /// sets without any bits, set or unset.
+    ///
+    /// ```
+    /// # use fixedbitset::FixedBitSet;
+    /// let mut bitset = FixedBitSet::with_capacity(10);
+    /// assert!(bitset.is_clear());
+    ///
+    /// bitset.insert(2);
+    /// assert!(!bitset.is_clear());
+    /// ```
+    ///
+    /// This is equivalent to [`bitset.count_ones(..) == 0`](FixedBitSet::count_ones).
+    #[inline]
+    pub fn is_clear(&self) -> bool {
+        self.data.iter().all(|block| *block == 0)
     }
 
     /// Return **true** if the bit is enabled in the **FixedBitSet**,


### PR DESCRIPTION
When using this library, the intent of checking if all elements in a bitset are disabled is better expressed with a specialized method. I doubt it's particularly more performant than `bitset.count_ones(..) == 0`, but when reading code using `FixedBitSet`, it's easier to understand what is going on with a `bitset.is_clear()` than a `bitset.count_ones(..) == 0`.

I also added docs so that it's less easy to get confused as to what "empty" means (I think the confusion was raised multiple times in the past)