### PR TITLE
Enable Clippy and rustfmt checks in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,4 +70,4 @@ jobs:
         override: true
     - name: Run Clippy
       run: |
-        cargo fmt --all -- check
+        cargo fmt --all --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}
@@ -31,3 +31,43 @@ jobs:
         cargo build --verbose --features "$FEATURES" &&
         cargo test --verbose --features "$FEATURES" &&
         cargo test --verbose --release --features "$FEATURES"
+
+  clippy:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Run Clippy only on stable
+        rust: [stable, nightly]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+        components: clippy
+        override: true
+    - name: Run Clippy
+      run: |
+        cargo clippy
+
+  formatting:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Run formatting checks only on stable
+        rust: [stable]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+        components: rustfmt
+        override: true
+    - name: Run Clippy
+      run: |
+        cargo fmt --all -- check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Run Clippy only on stable
-        rust: [stable, nightly]
+        rust: [stable]
 
     steps:
     - uses: actions/checkout@v2

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,17 +1,17 @@
 #![feature(test)]
 
-extern crate test;
 extern crate fixedbitset;
-use test::Bencher;
-use fixedbitset::{FixedBitSet, Block};
+extern crate test;
+use fixedbitset::{Block, FixedBitSet};
 use std::mem::size_of;
+use test::Bencher;
 
 #[inline]
 fn iter_ones_using_contains<F: FnMut(usize)>(fb: &FixedBitSet, f: &mut F) {
-    for bit in 0 .. fb.len() {
-       if fb.contains(bit) {
-           f(bit);
-       }
+    for bit in 0..fb.len() {
+        if fb.contains(bit) {
+            f(bit);
+        }
     }
 }
 
@@ -62,9 +62,9 @@ fn bench_iter_ones_using_slice_directly_all_zero(b: &mut Bencher) {
     let fb = FixedBitSet::with_capacity(N);
 
     b.iter(|| {
-       let mut count = 0;
-       iter_ones_using_slice_directly(&fb, &mut |_bit| count += 1);
-       count
+        let mut count = 0;
+        iter_ones_using_slice_directly(&fb, &mut |_bit| count += 1);
+        count
     });
 }
 
@@ -75,9 +75,9 @@ fn bench_iter_ones_using_slice_directly_all_ones(b: &mut Bencher) {
     fb.insert_range(..);
 
     b.iter(|| {
-       let mut count = 0;
-       iter_ones_using_slice_directly(&fb, &mut |_bit| count += 1);
-       count
+        let mut count = 0;
+        iter_ones_using_slice_directly(&fb, &mut |_bit| count += 1);
+        count
     });
 }
 
@@ -115,9 +115,7 @@ fn bench_insert_range(b: &mut Bencher) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
 
-    b.iter(|| {
-        fb.insert_range(..)
-    });
+    b.iter(|| fb.insert_range(..));
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,8 +531,9 @@ impl<'a> Iterator for Difference<'a> {
     type Item = usize;
 
     #[inline]
+    #[allow(clippy::manual_find)]
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(nxt) = self.iter.next() {
+        for nxt in self.iter.by_ref() {
             if !self.other.contains(nxt) {
                 return Some(nxt);
             }
@@ -569,8 +570,9 @@ impl<'a> Iterator for Intersection<'a> {
     type Item = usize; // the bit position of the '1'
 
     #[inline]
+    #[allow(clippy::manual_find)]
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(nxt) = self.iter.next() {
+        for nxt in self.iter.by_ref() {
             if self.other.contains(nxt) {
                 return Some(nxt);
             }
@@ -619,9 +621,9 @@ impl Masks {
         let (last_block, last_rem) = div_rem(end);
 
         Masks {
-            first_block: first_block as usize,
+            first_block,
             first_mask: Block::max_value() << first_rem,
-            last_block: last_block as usize,
+            last_block,
             last_mask: (Block::max_value() >> 1) >> (BITS - last_rem - 1),
             // this is equivalent to `MAX >> (BITS - x)` with correct semantics when x == 0.
         }
@@ -669,7 +671,7 @@ impl<'a> Iterator for Ones<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while self.bitset == 0 {
-            self.bitset  = *self.remaining_blocks.next()?;
+            self.bitset = *self.remaining_blocks.next()?;
             self.block_idx += BITS;
         }
         let t = self.bitset & (0 as Block).wrapping_sub(self.bitset);
@@ -749,13 +751,13 @@ impl<'a> BitAnd for &'a FixedBitSet {
     }
 }
 
-impl<'a> BitAndAssign for FixedBitSet {
+impl BitAndAssign for FixedBitSet {
     fn bitand_assign(&mut self, other: Self) {
         self.intersect_with(&other);
     }
 }
 
-impl<'a> BitAndAssign<&Self> for FixedBitSet {
+impl BitAndAssign<&Self> for FixedBitSet {
     fn bitand_assign(&mut self, other: &Self) {
         self.intersect_with(other);
     }
@@ -780,13 +782,13 @@ impl<'a> BitOr for &'a FixedBitSet {
     }
 }
 
-impl<'a> BitOrAssign for FixedBitSet {
+impl BitOrAssign for FixedBitSet {
     fn bitor_assign(&mut self, other: Self) {
         self.union_with(&other);
     }
 }
 
-impl<'a> BitOrAssign<&Self> for FixedBitSet {
+impl BitOrAssign<&Self> for FixedBitSet {
     fn bitor_assign(&mut self, other: &Self) {
         self.union_with(other);
     }
@@ -811,13 +813,13 @@ impl<'a> BitXor for &'a FixedBitSet {
     }
 }
 
-impl<'a> BitXorAssign for FixedBitSet {
+impl BitXorAssign for FixedBitSet {
     fn bitxor_assign(&mut self, other: Self) {
         self.symmetric_difference_with(&other);
     }
 }
 
-impl<'a> BitXorAssign<&Self> for FixedBitSet {
+impl BitXorAssign<&Self> for FixedBitSet {
     fn bitxor_assign(&mut self, other: &Self) {
         self.symmetric_difference_with(other);
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,39 +1,45 @@
-use std::ops::{
-    RangeFull,
-    RangeFrom,
-    RangeTo,
-    Range,
-};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
 // Taken from https://github.com/bluss/odds/blob/master/src/range.rs.
 
 /// **IndexRange** is implemented by Rust's built-in range types, produced
 /// by range syntax like `..`, `a..`, `..b` or `c..d`.
-pub trait IndexRange<T=usize> {
+pub trait IndexRange<T = usize> {
     #[inline]
     /// Start index (inclusive)
-    fn start(&self) -> Option<T> { None }
+    fn start(&self) -> Option<T> {
+        None
+    }
     #[inline]
     /// End index (exclusive)
-    fn end(&self) -> Option<T> { None }
+    fn end(&self) -> Option<T> {
+        None
+    }
 }
-
 
 impl<T> IndexRange<T> for RangeFull {}
 
 impl<T: Copy> IndexRange<T> for RangeFrom<T> {
     #[inline]
-    fn start(&self) -> Option<T> { Some(self.start) }
+    fn start(&self) -> Option<T> {
+        Some(self.start)
+    }
 }
 
 impl<T: Copy> IndexRange<T> for RangeTo<T> {
     #[inline]
-    fn end(&self) -> Option<T> { Some(self.end) }
+    fn end(&self) -> Option<T> {
+        Some(self.end)
+    }
 }
 
 impl<T: Copy> IndexRange<T> for Range<T> {
     #[inline]
-    fn start(&self) -> Option<T> { Some(self.start) }
+    fn start(&self) -> Option<T> {
+        Some(self.start)
+    }
     #[inline]
-    fn end(&self) -> Option<T> { Some(self.end) }
+    fn end(&self) -> Option<T> {
+        Some(self.end)
+    }
 }


### PR DESCRIPTION
This PR adds two jobs to CI that run clippy and rustfmt checks in CI. This should lead to more consistent code style with the rest of the Rust ecosystem, and check for common issues.

The code has been run through `cargo fmt --all` and `cargo clippy`, and all clippy lints have been addressed.