### PR TITLE
Add a zeroes iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,7 +732,7 @@ pub struct Zeroes<'a> {
 }
 
 impl<'a> Iterator for Zeroes<'a> {
-    type Item = usize; // the bit position of the '0'
+    type Item = usize; // the bit position of the '1'
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -745,7 +745,7 @@ impl<'a> Iterator for Zeroes<'a> {
         self.bitset ^= t;
         let bit = self.block_idx + r;
         // The remaining zeroes beyond the length of the bitset must be excluded.
-        (bit >= self.len).then(|| bit)
+        (bit < self.len).then(|| bit)
     }
 
     #[inline]
@@ -1692,6 +1692,34 @@ mod tests {
         assert_eq!(
             fb.ones().collect::<Vec<usize>>(),
             dup.ones().collect::<Vec<usize>>()
+        );
+    }
+
+    #[test]
+    fn zeroes() {
+        let len = 232;
+        let mut fb = FixedBitSet::with_capacity(len);
+        for i in (0..len).filter(|i| i % 7 == 0) {
+            fb.insert(i);
+        }
+        let zeroes = fb.zeroes().collect::<Vec<usize>>();
+
+        assert_eq!(
+            zeroes,
+            vec![
+                1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26,
+                27, 29, 30, 31, 32, 33, 34, 36, 37, 38, 39, 40, 41, 43, 44, 45, 46, 47, 48, 50, 51,
+                52, 53, 54, 55, 57, 58, 59, 60, 61, 62, 64, 65, 66, 67, 68, 69, 71, 72, 73, 74, 75,
+                76, 78, 79, 80, 81, 82, 83, 85, 86, 87, 88, 89, 90, 92, 93, 94, 95, 96, 97, 99,
+                100, 101, 102, 103, 104, 106, 107, 108, 109, 110, 111, 113, 114, 115, 116, 117,
+                118, 120, 121, 122, 123, 124, 125, 127, 128, 129, 130, 131, 132, 134, 135, 136,
+                137, 138, 139, 141, 142, 143, 144, 145, 146, 148, 149, 150, 151, 152, 153, 155,
+                156, 157, 158, 159, 160, 162, 163, 164, 165, 166, 167, 169, 170, 171, 172, 173,
+                174, 176, 177, 178, 179, 180, 181, 183, 184, 185, 186, 187, 188, 190, 191, 192,
+                193, 194, 195, 197, 198, 199, 200, 201, 202, 204, 205, 206, 207, 208, 209, 211,
+                212, 213, 214, 215, 216, 218, 219, 220, 221, 222, 223, 225, 226, 227, 228, 229,
+                230
+            ]
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,11 @@ impl<'a> Iterator for Zeroes<'a> {
         self.bitset ^= t;
         let bit = self.block_idx + r;
         // The remaining zeroes beyond the length of the bitset must be excluded.
-        (bit < self.len).then(|| bit)
+        if bit < self.len {
+            Some(bit)
+        } else {
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Adds an iterator, like `Ones`, named `Zeroes` that iterates over the unset bits in a bitset.

Note this is likely a bit less efficient than the `Ones` iterator due to it needing to ensure that the trailing zeros in the last block are not included in the results.

Added a test to ensure it was working as expected.

Fixes #7. Fixes #9. Supersedes #32. Supersedes #10.