### PR TITLE
add grow_and_insert method

### DIFF
--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -91,6 +91,19 @@ fn insert(c: &mut Criterion) {
     });
 }
 
+fn grow_and_insert(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb = FixedBitSet::with_capacity(N);
+
+    c.bench_function("grow_and_insert", |b| {
+        b.iter(|| {
+            for i in 0..N {
+                fb.grow_and_insert(i);
+            }
+        })
+    });
+}
+
 fn union_with(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb_a = FixedBitSet::with_capacity(N);
@@ -159,5 +172,6 @@ criterion_group!(
     symmetric_difference_with,
     count_ones,
     clear,
+    grow_and_insert,
 );
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,11 @@ impl FixedBitSet {
         }
     }
 
-    /// First grow to bits just like `grow`, then enable the bit
+    /// Grows the internal size of the bitset before inserting a bit
+    ///
+    /// Unlike `insert`, this cannot panic, but may allocate if the bit is outside of the existing buffer's range.
+    ///
+    /// This is faster than calling `grow` then `insert` in succession.
     #[inline]
     pub fn grow_and_insert(&mut self, bits: usize) {
         self.grow(bits + 1);


### PR DESCRIPTION
add a helper method `grow_and_insert`. I've seen bevy always calls with first grow(bits + 1), followed by a insert. like: https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/query/access.rs#L98