### PR TITLE
Adding an unchecked version of `union_with`

### DIFF
--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -112,6 +112,14 @@ fn union_with(c: &mut Criterion) {
     c.bench_function("union_with/1m", |b| b.iter(|| fb_a.union_with(&fb_b)));
 }
 
+fn union_with_unchecked(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let fb_b = FixedBitSet::with_capacity(N);
+
+    c.bench_function("union_with_unchecked/1m", |b| b.iter(|| fb_a.union_with_unchecked(&fb_b)));
+}
+
 fn intersect_with(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb_a = FixedBitSet::with_capacity(N);
@@ -169,6 +177,7 @@ criterion_group!(
     intersect_with,
     difference_with,
     union_with,
+    union_with_unchecked,
     symmetric_difference_with,
     count_ones,
     clear,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,7 +494,7 @@ impl FixedBitSet {
     /// If `other`'s capacity is larger than `self`'s, the extra bits will be ignored.
     pub fn union_with_unchecked(&mut self, other: &FixedBitSet) {
         for (x, y) in self.data.iter_mut().zip(other.data.iter()) {
-            *x |= *y; 
+            *x |= *y;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,8 +490,8 @@ impl FixedBitSet {
 
     /// In-place union of two `FixedBitSet`s.
     ///
-    /// This method will not check if the capacities are equal and may 
-    /// cause undefined behavior if they are not.
+    /// This method will not grow the capacity of `self` to match `other`'s.
+    /// If `other`'s capacity is larger than `self`'s, the extra bits will be ignored.
     pub fn union_with_unchecked(&mut self, other: &FixedBitSet) {
         for (x, y) in self.data.iter_mut().zip(other.data.iter()) {
             *x |= *y; 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,16 @@ impl FixedBitSet {
         }
     }
 
+    /// In-place union of two `FixedBitSet`s.
+    ///
+    /// This method will not check if the capacities are equal and may 
+    /// cause undefined behavior if they are not.
+    pub fn union_with_unchecked(&mut self, other: &FixedBitSet) {
+        for (x, y) in self.data.iter_mut().zip(other.data.iter()) {
+            *x |= *y; 
+        }
+    }
+
     /// In-place intersection of two `FixedBitSet`s.
     ///
     /// On calling this method, `self`'s capacity will remain the same as before.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1393,6 +1393,96 @@ mod tests {
     }
 
     #[test]
+    fn union_unchecked() {
+        let a_len = 100;
+        let b_len = 100;
+
+        let mut a = FixedBitSet::with_capacity(a_len);
+        let mut b = FixedBitSet::with_capacity(b_len);
+
+        for i in 0..b_len {
+            if i % 2 == 0 {
+                b.set(i, true);
+            }
+        }
+
+        a.union_with_unchecked(&b);
+        for i in 0..b_len {
+            if i % 2 == 0 {
+                assert!(a.contains(i));
+            } else {
+                assert!(!a.contains(i));
+            }
+        }
+    }
+
+    #[test]
+    fn union_unchecked_a_lt_b() {
+        let a_len = 50;
+        let b_len = 100;
+
+        let mut a = FixedBitSet::with_capacity(a_len);
+        let mut b = FixedBitSet::with_capacity(b_len);
+
+        // fill evens in `b`
+        for i in 0..b_len {
+            if i % 2 == 0 {
+                b.set(i, true);
+            }
+        }
+
+        // perform union
+        a.union_with_unchecked(&b);
+
+        // validate evens in `a`
+        for i in 0..a_len {
+            if i % 2 == 0 {
+                assert!(a.contains(i));
+            } else {
+                assert!(!a.contains(i));
+            }
+        }
+
+        // validate length of `a` is unchanged
+        assert_eq!(a.len(), a_len);
+    }
+
+    #[test]
+    fn union_unchecked_a_gt_b() {
+        let a_len = 100;
+        let b_len = 50;
+
+        let mut a = FixedBitSet::with_capacity(a_len);
+        let mut b = FixedBitSet::with_capacity(b_len);
+
+        // fill evens in `b`
+        for i in 0..b_len {
+            if i % 2 == 0 {
+                b.set(i, true);
+            }
+        }
+
+        // perform union
+        a.union_with_unchecked(&b);
+
+        // validate evens in `a`
+        for i in 0..a_len {
+            if i >= b_len {
+                assert!(!a.contains(i));
+            } else {
+                if i % 2 == 0 {
+                    assert!(a.contains(i));
+                } else {
+                    assert!(!a.contains(i));
+                }
+            }
+        }
+
+        // validate length of `a` is unchanged
+        assert_eq!(a.len(), a_len);
+    }
+
+    #[test]
     fn difference() {
         let a_len = 83;
         let b_len = 151;


### PR DESCRIPTION
Hey all,

Love the library and am using it in a project where I am performing a very high number of `union_with` calls on `FixedBitSet`s of equal length of fairly small size (i.e. N $\approx$ 1000).

I know that they are the same length every time so the extra branching in the `if` statement checking if they are equal sizes is adding overhead that could be cut. Not sure if you all are interested in including, but I found it to be very helpful in my project and made a fairly substantial optimization. 

The effect is fairly small for larger bitsets (1M) but is significant once the size gets much smaller.

Here are the benchmarks:

## N = 1k
```
union_with/1k time:   [6.9713 ns 6.9860 ns 7.0021 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

union_with_unchecked/1k time:   [4.4989 ns 4.5232 ns 4.5489 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

## N = 1M 
```
union_with/1m           time:   [4.5301 µs 4.5315 µs 4.5329 µs]
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

union_with_unchecked/1m time:   [4.5138 µs 4.5161 µs 4.5184 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  2 (2.00%) high severe
```
