### PR TITLE
Add DoubleEndedIterator to Ones for reverse iteration

### DIFF
--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -58,8 +58,8 @@ fn iter_ones_all_zeros(c: &mut Criterion) {
 fn iter_ones_sparse(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
-    for i in 0..N{
-        if i % 2 == 0{
+    for i in 0..N {
+        if i % 2 == 0 {
             fb.insert(i);
         }
     }
@@ -177,8 +177,21 @@ fn count_ones(c: &mut Criterion) {
     });
 }
 
+fn bitchange(c: &mut Criterion) {
+    let mut val: fixedbitset::Block = 1234;
+    c.bench_function("bitops/change_last_bit", |b| {
+        b.iter(|| {
+            val += 1;
+            val = val.rotate_left(10);
+            fixedbitset::Ones::last_positive_bit_and_unset(&mut val);
+            black_box(val)
+        })
+    });
+}
+
 criterion_group!(
     benches,
+    bitchange,
     iter_ones_using_contains_all_zeros,
     iter_ones_using_contains_all_ones,
     iter_ones_all_zeros,

--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -90,6 +90,22 @@ fn iter_ones_all_ones(c: &mut Criterion) {
     });
 }
 
+fn iter_ones_all_ones_rev(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb = FixedBitSet::with_capacity(N);
+    fb.insert_range(..);
+
+    c.bench_function("iter_ones/all_ones", |b| {
+        b.iter(|| {
+            let mut count = 0;
+            for _ in fb.ones().rev() {
+                count += 1;
+            }
+            count
+        })
+    });
+}
+
 fn insert_range(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
@@ -174,18 +190,6 @@ fn count_ones(c: &mut Criterion) {
 
     c.bench_function("count_ones/1m", |b| {
         b.iter(|| black_box(fb_a.count_ones(..)))
-    });
-}
-
-fn bitchange(c: &mut Criterion) {
-    let mut val: fixedbitset::Block = 1234;
-    c.bench_function("bitops/change_last_bit", |b| {
-        b.iter(|| {
-            val += 1;
-            val = val.rotate_left(10);
-            fixedbitset::Ones::last_positive_bit_and_unset(&mut val);
-            black_box(val)
-        })
     });
 }
 

--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -55,6 +55,25 @@ fn iter_ones_all_zeros(c: &mut Criterion) {
     });
 }
 
+fn iter_ones_sparse(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb = FixedBitSet::with_capacity(N);
+    for i in 0..N{
+        if i % 2 == 0{
+            fb.insert(i);
+        }
+    }
+    c.bench_function("iter_ones/sparse", |b| {
+        b.iter(|| {
+            let mut count = 0;
+            for _ in fb.ones() {
+                count += 1;
+            }
+            count
+        })
+    });
+}
+
 fn iter_ones_all_ones(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
@@ -163,6 +182,7 @@ criterion_group!(
     iter_ones_using_contains_all_zeros,
     iter_ones_using_contains_all_ones,
     iter_ones_all_zeros,
+    iter_ones_sparse,
     iter_ones_all_ones,
     insert_range,
     insert,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,6 +779,7 @@ pub struct Ones<'a> {
 }
 
 impl<'a> Ones<'a> {
+    #[inline]
     pub fn last_positive_bit_and_unset(n: &mut Block) -> usize {
         // Find the last set bit using x & -x
         let last_bit = *n & n.wrapping_neg();
@@ -786,7 +787,7 @@ impl<'a> Ones<'a> {
         // Find the position of the last set bit
         let position = last_bit.trailing_zeros();
 
-        // Unset the last set bit using x & (x - 1)
+        // Unset the last set bit
         *n &= *n - 1;
 
         position as usize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,31 +814,31 @@ impl<'a> Iterator for Ones<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        //let mut active_block: &mut Block = &mut self.bitset_front;
         while self.bitset_front == 0 {
             match self.remaining_blocks.next() {
+                Some(next_block) => {
+                self.bitset_front = *next_block;
+                self.block_idx_front += BITS;
+            }
                 None => {
                     if self.bitset_back != 0 {
                         self.bitset_front = 0;
-                        self.block_idx_front = self.block_idx_back;
-                        let t = self.bitset_back & (0 as Block).wrapping_sub(self.bitset_back);
-                        let r = self.bitset_back.trailing_zeros() as usize;
-                        self.bitset_back ^= t;
-                        return Some(self.block_idx_back + r);
+                        let bit_idx = self.bitset_back.trailing_zeros();
+                        let mask = !((1 as Block) << (bit_idx));
+                        self.bitset_back.bitand_assign(mask);
+                        return Some(self.block_idx_back + bit_idx as Block);
                     } else {
                         return None;
                     }
                 }
-                Some(next_block) => {
-                    self.bitset_front = *next_block;
-                    self.block_idx_front += BITS;
-                }
+
             };
         }
-        let t = self.bitset_front & (0 as Block).wrapping_sub(self.bitset_front);
-        let r = self.bitset_front.trailing_zeros() as usize;
-        self.bitset_front ^= t;
-        Some(self.block_idx_front + r)
+        let bit_idx = self.bitset_front.trailing_zeros();
+        let mask = !((1 as Block) << (bit_idx));
+        self.bitset_front.bitand_assign(mask);
+
+        Some(self.block_idx_front + bit_idx as Block)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -794,7 +794,7 @@ impl<'a> Ones<'a> {
     }
 
     #[inline]
-    pub fn first_positive_bit_and_unset(n: &mut Block) -> usize {
+    fn first_positive_bit_and_unset(n: &mut Block) -> usize {
         /* Identify the first non zero bit */
         let bit_idx = n.leading_zeros();
 


### PR DESCRIPTION
Hi,
I needed the ability to iterate through the set in reverse.
I looked into it and implemented the `DoubleEndedIterator` for `Ones`.
This makes the iterator struct slightly larger. I added one Block and one index (usize) to the struct.
The pull request also includes testing and benchmarks modifications to utilize this feature.
Benchmark performance remains the same on my machine.
If there is interest in this, I'm happy to implement the same for `Zeros`.