### PR TITLE
Fix Serde implementation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.39.0, stable, nightly]
+        rust: [1.56.0, stable, nightly]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .idea/
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["container", "data-structure", "bitvec", "bitset", "no_std"]
 categories = ["data-structures"]
 
 [features]
-serde = ["dep:serde", "std"]
 std = []
 default = ["std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.4.2"
 authors = ["bluss"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+rust-version = "1.56"
+edition = "2021"
 
 description = "FixedBitSet is a simple bitset collection"
 documentation = "https://docs.rs/fixedbitset/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["container", "data-structure", "bitvec", "bitset", "no_std"]
 categories = ["data-structures"]
 
 [features]
+serde = ["dep:serde", "std"]
 std = []
 default = ["std"]
 
@@ -21,7 +22,7 @@ no-dev-version = true
 tag-name = "{{version}}"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -195,12 +195,12 @@ fn count_ones(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bitchange,
     iter_ones_using_contains_all_zeros,
     iter_ones_using_contains_all_ones,
     iter_ones_all_zeros,
     iter_ones_sparse,
     iter_ones_all_ones,
+    iter_ones_all_ones_rev,
     insert_range,
     insert,
     intersect_with,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use std::iter::{Chain, ExactSizeIterator, FromIterator, FusedIterator};
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index};
 
 pub(crate) const BITS: usize = std::mem::size_of::<Block>() * 8;
+#[cfg(feature = "serde")]
 pub(crate) const BYTES: usize = std::mem::size_of::<Block>();
 
 pub type Block = usize;

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use core as std;
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
 // Taken from https://github.com/bluss/odds/blob/master/src/range.rs.

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,0 +1,140 @@
+use crate::std::{convert::TryFrom, fmt};
+use crate::{FixedBitSet, BYTES};
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+struct BitSetByteSerializer<'a>(&'a FixedBitSet);
+
+impl Serialize for FixedBitSet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut struct_serializer = serializer.serialize_struct("FixedBitset", 2)?;
+        struct_serializer.serialize_field("length", &(self.length as u64))?;
+        struct_serializer.serialize_field("data", &BitSetByteSerializer(self))?;
+        struct_serializer.end()
+    }
+}
+
+impl<'a> Serialize for BitSetByteSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = self.0.data.len() * BYTES;
+        // PERF: Figure out a way to do this without allocating.
+        let mut temp = Vec::with_capacity(len);
+        for block in &self.0.data {
+            temp.extend(&block.to_le_bytes());
+        }
+        serializer.serialize_bytes(&temp)
+    }
+}
+
+impl<'de> Deserialize<'de> for FixedBitSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Length,
+            Data,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`length` or `data`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "length" => Ok(Field::Length),
+                            "data" => Ok(Field::Data),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct FixedBitSetVisitor;
+
+        impl<'de> Visitor<'de> for FixedBitSetVisitor {
+            type Value = FixedBitSet;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Duration")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<FixedBitSet, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let length = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let data = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                Ok(FixedBitSet { length, data })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<FixedBitSet, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut length = None;
+                let mut temp: Option<&[u8]> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Length => {
+                            if length.is_some() {
+                                return Err(de::Error::duplicate_field("length"));
+                            }
+                            length = Some(map.next_value()?);
+                        }
+                        Field::Data => {
+                            if temp.is_some() {
+                                return Err(de::Error::duplicate_field("data"));
+                            }
+                            temp = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let length = length.ok_or_else(|| de::Error::missing_field("length"))?;
+                let temp = temp.ok_or_else(|| de::Error::missing_field("data"))?;
+                let block_len = length / BYTES + 1;
+                let mut data = Vec::with_capacity(block_len);
+                for chunk in temp.chunks(BYTES) {
+                    match <&[u8; BYTES]>::try_from(chunk) {
+                        Ok(bytes) => data.push(usize::from_le_bytes(*bytes)),
+                        Err(_) => {
+                            let mut bytes = [0u8; BYTES];
+                            bytes[0..BYTES].copy_from_slice(chunk);
+                            data.push(usize::from_le_bytes(bytes));
+                        }
+                    }
+                }
+                Ok(FixedBitSet { length, data })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["length", "data"];
+        deserializer.deserialize_struct("Duration", FIELDS, FixedBitSetVisitor)
+    }
+}

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,10 +1,10 @@
 #[cfg(not(feature = "std"))]
 use core as std;
 
-use std::{convert::TryFrom, fmt};
 use crate::{FixedBitSet, BYTES};
 use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
+use std::{convert::TryFrom, fmt};
 
 struct BitSetByteSerializer<'a>(&'a FixedBitSet);
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,4 +1,7 @@
-use crate::std::{convert::TryFrom, fmt};
+#[cfg(not(feature = "std"))]
+use core as std;
+
+use std::{convert::TryFrom, fmt};
 use crate::{FixedBitSet, BYTES};
 use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};


### PR DESCRIPTION
Since #74, the serde implementation has been platform dependent due to the use of `usize` as the inner block.

This PR fixes that by providing a platform agnostic manual serde implementation by converting blocks to a fixed little-endian representation, then serializing the entire byte buffer. Unfortunately this involves allocation during serialization, but it's preferable to having serde broken when moving from platform to platform.

This is a breaking change and existing instances of the serialized bitset will be broken.