### PR TITLE
v0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixedbitset"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["bluss"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fixedbitset
 ---
 
-A simple bitset container for Rust
+A simple fixed size bitset container for Rust.
 
 Please read the [API documentation here](https://docs.rs/fixedbitset/)
 
@@ -10,6 +10,8 @@ Please read the [API documentation here](https://docs.rs/fixedbitset/)
 
 # Recent Changes
 
+-   0.5.2
+    - [#86](https://github.com/petgraph/fixedbitset/pull/86): Explicit SIMD vectorization for set operations by @james7132.
 -   0.5.1
     - [#102](https://github.com/petgraph/fixedbitset/pull/102): Added `contains_unchecked`, `insert_unchecked`, `put_unchecked`,
       `set_unchecked`, `toggle_unchecked`, `removed_unchecked`, `copy_bit_unchecked` unsafe variants of the safe functions, by @james7132

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 //! `FixedBitSet` is a simple fixed size set of bits.
 //!
-//!
 //! ### Crate features
 //!
 //! - `std` (default feature)  
 //!   Disabling this feature disables using std and instead uses crate alloc.
-//!   Requires Rust 1.36 to disable.
 //!
-//! ### Rust Version
+//! ### SIMD Acceleration
+//! `fixedbitset` is written with SIMD in mind. The backing store and set operations will use aligned SIMD data types and instructions when compiling
+//! for compatible target platforms. The use of SIMD generally enables better performance in many set and batch operations (i.e. intersection/union/inserting a range).
 //!
-//! This version of fixedbitset requires Rust 1.39 or later.
+//!  When SIMD is not available on the target, the crate will gracefully fallback to a default implementation.  It is intended to add support for other SIMD architectures
+//! once they appear in stable Rust.
 //!
-#![doc(html_root_url = "https://docs.rs/fixedbitset/0.4.2/")]
+//! Currently only SSE2/AVX2 on x86/x86_64 and wasm32 SIMD are supported as this is what stable Rust supports.
 #![no_std]
 #![deny(clippy::undocumented_unsafe_blocks)]
 
@@ -33,7 +34,7 @@ use core::fmt::{Binary, Display, Error, Formatter};
 use core::{fmt::Write, mem::ManuallyDrop};
 
 use core::cmp::{Ord, Ordering};
-use core::iter::{Chain, ExactSizeIterator, FromIterator, FusedIterator};
+use core::iter::{Chain, FusedIterator};
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index};
 pub use range::IndexRange;
 
@@ -1054,9 +1055,9 @@ impl<'a> Iterator for Ones<'a> {
 // Ones will continue to return None once it first returns None.
 impl<'a> FusedIterator for Ones<'a> {}
 
-/// An  iterator producing the indices of the unset bit in a set.
+/// An  iterator producing the indices of the set bit in a set.
 ///
-/// This struct is created by the [`FixedBitSet::zeroes`] method.
+/// This struct is created by the [`FixedBitSet::ones`] method.
 pub struct Zeroes<'a> {
     bitset: usize,
     block_idx: usize,


### PR DESCRIPTION
This publishes the SIMD acceleration, updates the README, and the crate level documentation to match.