### PR TITLE
Fix non-x86(_64) builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,22 +18,40 @@ jobs:
     strategy:
       matrix:
         rust: [1.56.0, stable, nightly]
-        features: ["+avx2", "+sse2", "-avx2,-sse2"]
+        features: ["+avx2", "+sse2"]
     env:
       RUSTFLAGS: "-C target-feature=${{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
+        target: x86_64-unknown-linux-gnu
         profile: minimal
         toolchain: ${{ matrix.rust }}
         override: true
-    - name: Tests
+    - name: Tests (x86_64)
       run: |
         cargo test -v --no-default-features --tests --lib &&
         cargo build --verbose --features "$FEATURES" &&
         cargo test --verbose --features "$FEATURES" &&
         cargo test --verbose --release --features "$FEATURES"
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [1.56.0, stable, nightly]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+        with:
+      with:
+        target: aarch64-unknown-linux-gnu
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+        override: true
+    - name: Tests (aarch64)
+      run: |
+        run: cargo check --target aarch64-unknown-linux-gnu
 
   # Use clippy to lint for code smells
   clippy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [1.56.0, stable, nightly]
         features: ["+avx2", "+sse2", "-avx2,-sse2"]
     env:
-      RUSTFLAGS: "-C target-features={{matrix.features}}"
+      RUSTFLAGS: "-C target-feature={{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [1.56.0, stable, nightly]
         features: ["+avx2", "+sse2", "-avx2,-sse2"]
     env:
-      RUSTFLAGS: "-C target-feature={{matrix.features}}"
+      RUSTFLAGS: "-C target-feature=${{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,7 @@ env:
 
 jobs:
   # Ensure the crate builds
-  build:
-
+  build_x86_64:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,6 +35,7 @@ jobs:
         cargo test --verbose --features "$FEATURES" &&
         cargo test --verbose --release --features "$FEATURES"
 
+  build_aarch64:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -54,7 +54,6 @@ jobs:
 
   # Use clippy to lint for code smells
   clippy:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,13 +74,11 @@ jobs:
 
   # Enforce rustfmt formatting
   formatting:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Run formatting checks only on stable
         rust: [stable]
-
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -96,13 +93,11 @@ jobs:
 
   # Ensure the benchmarks compile
   benchmark_compiles:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Check builds only on stable
         rust: [stable]
-
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,8 +49,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
     - name: Tests (aarch64)
-      run: |
-        run: cargo check --target aarch64-unknown-linux-gnu
+      run: cargo check --target aarch64-unknown-linux-gnu
 
   # Use clippy to lint for code smells
   clippy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,6 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [1.56.0, stable, nightly]
         features: ["+avx2", "+sse2", "-avx2,-sse2"]
     env:
-      RUSTCFLAGS: "-C target-features={{matrix.features}}"
+      RUSTFLAGS: "-C target-features={{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-        with:
       with:
         target: aarch64-unknown-linux-gnu
         profile: minimal

--- a/src/block/default.rs
+++ b/src/block/default.rs
@@ -12,6 +12,16 @@ impl Block {
     pub const BITS: usize = core::mem::size_of::<Self>() * 8;
 
     #[inline]
+    pub fn into_usize_array(self) -> [usize; Self::USIZE_COUNT] {
+        [self.0]
+    }
+
+    #[inline]
+    pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
+        Self(array[0])
+    }
+
+    #[inline]
     pub const fn is_empty(self) -> bool {
         self.0 == Self::NONE.0
     }

--- a/src/block/default.rs
+++ b/src/block/default.rs
@@ -12,16 +12,6 @@ impl Block {
     pub const BITS: usize = core::mem::size_of::<Self>() * 8;
 
     #[inline]
-    pub fn into_usize_array(self) -> [usize; Self::USIZE_COUNT] {
-        [self.0]
-    }
-
-    #[inline]
-    pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
-        Self(array[0])
-    }
-
-    #[inline]
     pub const fn is_empty(self) -> bool {
         self.0 == Self::NONE.0
     }


### PR DESCRIPTION
Non-x86 builds were failing due to some missing functions on the default impl. This PR fixes that.

This should have been caught by CI, but there was a typo ("RUSTFLAGS", not "RUSTCFLAGS")