### PR TITLE
Add functions for counting the results of a set operation

### DIFF
--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -139,6 +139,110 @@ fn grow_and_insert(c: &mut Criterion) {
     });
 }
 
+fn iter_union_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_union_count/1m", |b| {
+        b.iter(|| black_box(fb_a.union(&fb_b).count()))
+    });
+}
+
+fn iter_intersect_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_intersection_count/1m", |b| {
+        b.iter(|| black_box(fb_a.intersection(&fb_b).count()));
+    });
+}
+
+fn iter_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.difference(&fb_b).count()));
+    });
+}
+
+fn iter_symmetric_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_symmetric_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.symmetric_difference(&fb_b).count()));
+    });
+}
+
+fn union_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("union_count/1m", |b| {
+        b.iter(|| black_box(fb_a.union_count(&fb_b)))
+    });
+}
+
+fn intersect_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("intersection_count/1m", |b| {
+        b.iter(|| black_box(fb_a.intersection_count(&fb_b)));
+    });
+}
+
+fn difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.difference_count(&fb_b)));
+    });
+}
+
+fn symmetric_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("symmetric_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.symmetric_difference_count(&fb_b)));
+    });
+}
+
 fn union_with(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb_a = FixedBitSet::with_capacity(N);
@@ -201,6 +305,14 @@ criterion_group!(
     iter_ones_sparse,
     iter_ones_all_ones,
     iter_ones_all_ones_rev,
+    iter_union_count,
+    iter_intersect_count,
+    iter_difference_count,
+    iter_symmetric_difference_count,
+    union_count,
+    intersect_count,
+    difference_count,
+    symmetric_difference_count,
     insert_range,
     insert,
     intersect_with,


### PR DESCRIPTION
Using `count_ones` with a set operation either requires mutating the underlying `FixedBitset` with `union_with`, etc, or using `Iterator::count` on the set operation iterators, which can be very slow on dense bitsets. This PR adds non-mutating options for computing the size of a union, intersection, difference, and symmetric difference between two bitsets.

Added a few benchmarks to measure the difference:

```
clear/1m                              1.00   1121.6±5.57ns        ? ?/sec
count_ones/1m                         1.00      7.8±0.01µs        ? ?/sec
difference_count/1m                   1.00      8.8±0.01µs        ? ?/sec
difference_with/1m                    1.00      2.9±0.01µs        ? ?/sec
grow_and_insert                       1.00      2.4±0.01ms        ? ?/sec
insert/1m                             1.00    967.5±3.45µs        ? ?/sec
insert_range/1m                       1.00   1116.8±7.00ns        ? ?/sec
intersect_with/1m                     1.00      2.9±0.01µs        ? ?/sec
intersection_count/1m                 1.00      8.8±0.08µs        ? ?/sec
iter_difference_count/1m              1.00   915.3±26.40µs        ? ?/sec
iter_intersection_count/1m            1.00   1706.6±4.52µs        ? ?/sec
iter_ones/all_ones                    1.00      2.3±0.00ms        ? ?/sec
iter_ones/all_zeros                   1.00      4.4±0.34µs        ? ?/sec
iter_ones/contains_all_ones           1.00    408.3±8.22µs        ? ?/sec
iter_ones/contains_all_zeros          1.00    406.7±2.59µs        ? ?/sec
iter_ones/sparse                      1.00    210.6±2.28µs        ? ?/sec
iter_symmetric_difference_count/1m    1.00      2.8±0.24ms        ? ?/sec
iter_union_count/1m                   1.00  1618.6±54.83µs        ? ?/sec
symmetric_difference_count/1m         1.00      8.8±0.02µs        ? ?/sec
symmetric_difference_with/1m          1.00      2.7±0.01µs        ? ?/sec
union_count/1m                        1.00      8.8±0.02µs        ? ?/sec
union_with/1m                         1.00      2.8±0.01µs        ? ?/sec
```

Comparing `iter_union_count` and `union_count`, on denser bitsets, using `union_count` is almost 200x faster, with the speed of `union_count` being only a bit behind `count_ones`.