### PR TITLE
Run CI on aarch64 and run clippy on all platforms

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  # Ensure the crate builds
+  # Ensure the crate builds on x86
   build_x86_64:
     runs-on: ubuntu-latest
     strategy:
@@ -28,42 +28,34 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - name: Tests (x86_64)
       run: |
+        cargo clippy -D warnings &&
         cargo test -v --no-default-features --tests --lib &&
         cargo build --verbose --features "$FEATURES" &&
         cargo test --verbose --features "$FEATURES" &&
         cargo test --verbose --release --features "$FEATURES"
 
+  # Ensure the crate builds on ARM
   build_aarch64:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     strategy:
       matrix:
         rust: [1.56.0, stable, nightly]
+        features: ["+neon", "-neon"]
+    env:
+      RUSTFLAGS: "-C target-feature=${{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        target: aarch64-unknown-linux-gnu
+        target: aarch64-apple-darwin
         toolchain: ${{ matrix.rust }}
     - name: Tests (aarch64)
-      run: cargo check --target aarch64-unknown-linux-gnu
-
-  # Use clippy to lint for code smells
-  clippy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Run Clippy only on stable
-        rust: [stable]
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: ${{ matrix.rust }}
-        components: clippy
-    - name: Run Clippy
       run: |
-        cargo clippy
+        cargo clippy -D warnings &&
+        cargo test -v --no-default-features --tests --lib &&
+        cargo build --verbose --features "$FEATURES" &&
+        cargo test --verbose --features "$FEATURES" &&
+        cargo test --verbose --release --features "$FEATURES"
 
   # Enforce rustfmt formatting
   formatting:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         target: x86_64-unknown-linux-gnu
         toolchain: ${{ matrix.rust }}
+        components: clippy
     - name: Tests (x86_64)
       run: |
         cargo clippy &&
@@ -49,6 +50,7 @@ jobs:
       with:
         target: aarch64-apple-darwin
         toolchain: ${{ matrix.rust }}
+        components: clippy
     - name: Tests (aarch64)
       run: |
         cargo clippy &&

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         rust: [1.56.0, stable, nightly]
         features: ["+avx2", "+sse2"]
     env:
-      RUSTFLAGS: "-C target-feature=${{matrix.features}}"
+      RUSTFLAGS: "-C target-feature=${{matrix.features}} -D warnings"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -28,7 +28,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - name: Tests (x86_64)
       run: |
-        cargo clippy -D warnings &&
+        cargo clippy &&
         cargo test -v --no-default-features --tests --lib &&
         cargo build --verbose --features "$FEATURES" &&
         cargo test --verbose --features "$FEATURES" &&
@@ -42,7 +42,7 @@ jobs:
         rust: [1.56.0, stable, nightly]
         features: ["+neon", "-neon"]
     env:
-      RUSTFLAGS: "-C target-feature=${{matrix.features}}"
+      RUSTFLAGS: "-C target-feature=${{matrix.features}} -D warnings"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -51,7 +51,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - name: Tests (aarch64)
       run: |
-        cargo clippy -D warnings &&
+        cargo clippy &&
         cargo test -v --no-default-features --tests --lib &&
         cargo build --verbose --features "$FEATURES" &&
         cargo test --verbose --features "$FEATURES" &&

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,10 +16,34 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.56.0, stable, nightly]
+        rust: [stable, nightly]
         features: ["+avx2", "+sse2"]
     env:
       RUSTFLAGS: "-C target-feature=${{matrix.features}} -D warnings"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: x86_64-unknown-linux-gnu
+        toolchain: ${{ matrix.rust }}
+        components: clippy
+    - name: Tests (x86_64)
+      run: |
+        cargo clippy &&
+        cargo test -v --no-default-features --tests --lib &&
+        cargo build --verbose --features "$FEATURES" &&
+        cargo test --verbose --features "$FEATURES" &&
+        cargo test --verbose --release --features "$FEATURES"
+
+  # Ensure the crate builds on x86
+  build_MSRV:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [1.56.0]
+        features: ["+avx2", "+sse2"]
+    env:
+      RUSTFLAGS: "-C target-feature=${{matrix.features}}"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -40,7 +64,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        rust: [1.56.0, stable, nightly]
+        rust: [stable, nightly]
         features: ["+neon", "-neon"]
     env:
       RUSTFLAGS: "-C target-feature=${{matrix.features}} -D warnings"

--- a/benches/benches/benches.rs
+++ b/benches/benches/benches.rs
@@ -139,6 +139,110 @@ fn grow_and_insert(c: &mut Criterion) {
     });
 }
 
+fn iter_union_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_union_count/1m", |b| {
+        b.iter(|| black_box(fb_a.union(&fb_b).count()))
+    });
+}
+
+fn iter_intersect_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_intersection_count/1m", |b| {
+        b.iter(|| black_box(fb_a.intersection(&fb_b).count()));
+    });
+}
+
+fn iter_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.difference(&fb_b).count()));
+    });
+}
+
+fn iter_symmetric_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("iter_symmetric_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.symmetric_difference(&fb_b).count()));
+    });
+}
+
+fn union_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("union_count/1m", |b| {
+        b.iter(|| black_box(fb_a.union_count(&fb_b)))
+    });
+}
+
+fn intersect_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("intersection_count/1m", |b| {
+        b.iter(|| black_box(fb_a.intersection_count(&fb_b)));
+    });
+}
+
+fn difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.difference_count(&fb_b)));
+    });
+}
+
+fn symmetric_difference_count(c: &mut Criterion) {
+    const N: usize = 1_000_000;
+    let mut fb_a = FixedBitSet::with_capacity(N);
+    let mut fb_b = FixedBitSet::with_capacity(N);
+
+    fb_a.insert_range(..);
+    fb_b.insert_range(..);
+
+    c.bench_function("symmetric_difference_count/1m", |b| {
+        b.iter(|| black_box(fb_a.symmetric_difference_count(&fb_b)));
+    });
+}
+
 fn union_with(c: &mut Criterion) {
     const N: usize = 1_000_000;
     let mut fb_a = FixedBitSet::with_capacity(N);
@@ -201,6 +305,14 @@ criterion_group!(
     iter_ones_sparse,
     iter_ones_all_ones,
     iter_ones_all_ones_rev,
+    iter_union_count,
+    iter_intersect_count,
+    iter_difference_count,
+    iter_symmetric_difference_count,
+    union_count,
+    intersect_count,
+    difference_count,
+    symmetric_difference_count,
     insert_range,
     insert,
     intersect_with,

--- a/src/block/avx2.rs
+++ b/src/block/avx2.rs
@@ -2,12 +2,7 @@
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-use core::{
-    cmp::Ordering,
-    hash::{Hash, Hasher},
-    iter::Iterator,
-    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
-};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]

--- a/src/block/default.rs
+++ b/src/block/default.rs
@@ -1,4 +1,3 @@
-
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/src/block/default.rs
+++ b/src/block/default.rs
@@ -1,4 +1,4 @@
-use core::iter::Iterator;
+
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -8,6 +8,7 @@ pub struct Block(usize);
 impl Block {
     pub const USIZE_COUNT: usize = 1;
     pub const NONE: Self = Block(0);
+    #[allow(dead_code)]
     pub const ALL: Self = Block(!0);
     pub const BITS: usize = core::mem::size_of::<Self>() * 8;
 
@@ -17,6 +18,7 @@ impl Block {
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
         Self(array[0])
     }

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,13 +681,12 @@ impl FixedBitSet {
     pub fn union_count(&self, other: &FixedBitSet) -> usize {
         let me = self.as_slice();
         let other = other.as_slice();
-        let mut count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| (*x | *y)));
-        if other.len() > me.len() {
-            count += Self::batch_count_ones(other[me.len()..].iter().copied());
-        } else if self.len() > other.len() {
-            count += Self::batch_count_ones(me[other.len()..].iter().copied());
+        let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| (*x | *y)));
+        match other.len().cmp(&me.len()) {
+            Ordering::Greater => count + Self::batch_count_ones(other[me.len()..].iter().copied()),
+            Ordering::Less => count + Self::batch_count_ones(me[other.len()..].iter().copied()),
+            Ordering::Equal => count,
         }
-        count
     }
 
     /// Computes how many bits would be set in the intersection between two bitsets.
@@ -730,12 +729,10 @@ impl FixedBitSet {
         let me = self.as_slice();
         let other = other.as_slice();
         let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| (*x ^ *y)));
-        if other.len() > me.len() {
-            count + Self::batch_count_ones(other[me.len()..].iter().copied())
-        } else if me.len() > other.len() {
-            count + Self::batch_count_ones(me[other.len()..].iter().copied())
-        } else {
-            count
+        match other.len().cmp(&me.len()) {
+            Ordering::Greater => count + Self::batch_count_ones(other[me.len()..].iter().copied()),
+            Ordering::Less => count + Self::batch_count_ones(me[other.len()..].iter().copied()),
+            Ordering::Equal => count,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,7 +802,6 @@ impl<'a> Iterator for Difference<'a> {
     type Item = usize;
 
     #[inline]
-    #[allow(clippy::manual_find)]
     fn next(&mut self) -> Option<Self::Item> {
         for nxt in self.iter.by_ref() {
             if !self.other.contains(nxt) {
@@ -872,7 +871,6 @@ impl<'a> Iterator for Intersection<'a> {
     type Item = usize; // the bit position of the '1'
 
     #[inline]
-    #[allow(clippy::manual_find)]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.by_ref().find(|&nxt| self.other.contains(nxt))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,12 +803,7 @@ impl<'a> Iterator for Difference<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        for nxt in self.iter.by_ref() {
-            if !self.other.contains(nxt) {
-                return Some(nxt);
-            }
-        }
-        None
+        self.iter.by_ref().find(|&nxt| !self.other.contains(nxt))
     }
 
     #[inline]


### PR DESCRIPTION
Taken from #115, credit @msvbg for setting this up.

This PR adds running aarch64 via macos 14 to ensure that tests are not broken on the platform, as well as enabling clippy to run on all targets with deny warnings on.