### PR TITLE
Shirnk stack size of FixedBitset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ impl FixedBitSet {
     }
 
     /// Grow capacity to **bits**, all new bits initialized to zero
+    #[inline]
     pub fn grow(&mut self, bits: usize) {
         let (mut blocks, rem) = div_rem(bits, SimdBlock::BITS);
         blocks += (rem > 0) as usize;
@@ -143,20 +144,24 @@ impl FixedBitSet {
         }
     }
 
+    #[inline]
     unsafe fn get_unchecked(&self, subblock: usize) -> &Block {
         &*self.data.as_ptr().cast::<Block>().add(subblock)
     }
 
+    #[inline]
     unsafe fn get_unchecked_mut(&mut self, subblock: usize) -> &mut Block {
         &mut *self.data.as_ptr().cast::<Block>().add(subblock)
     }
 
+    #[inline]
     fn usize_len(&self) -> usize {
         let (mut blocks, rem) = div_rem(self.length, BITS);
         blocks += (rem > 0) as usize;
         blocks
     }
 
+    #[inline]
     fn simd_block_len(&self) -> usize {
         let (mut blocks, rem) = div_rem(self.length, SimdBlock::BITS);
         blocks += (rem > 0) as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,12 +91,16 @@ impl FixedBitSet {
     pub fn with_capacity(bits: usize) -> Self {
         let (mut blocks, rem) = div_rem(bits, SimdBlock::BITS);
         blocks += (rem > 0) as usize;
-        let data = vec![SimdBlock::NONE; blocks];
+        Self::from_blocks_and_len(vec![SimdBlock::NONE; blocks], bits)
+    }
+
+    #[inline]
+    fn from_blocks_and_len(data: Vec<SimdBlock>, length: usize) -> Self {
         let (data, capacity, _) = vec_into_parts(data);
         FixedBitSet {
             data,
             capacity,
-            length: bits,
+            length,
         }
     }
 
@@ -1243,13 +1247,7 @@ impl<'a> FusedIterator for Zeroes<'a> {}
 impl Clone for FixedBitSet {
     #[inline]
     fn clone(&self) -> Self {
-        let data = Vec::from(self.as_simd_slice());
-        let (data, capacity, _) = vec_into_parts(data);
-        FixedBitSet {
-            data,
-            capacity,
-            length: self.length,
-        }
+        Self::from_blocks_and_len(Vec::from(self.as_simd_slice()), self.length)
     }
 }
 
@@ -1421,12 +1419,7 @@ impl<'a> BitAnd for &'a FixedBitSet {
             *data &= *block;
         }
         let len = core::cmp::min(self.len(), other.len());
-        let (data, capacity, _) = vec_into_parts(data);
-        FixedBitSet {
-            data,
-            capacity,
-            length: len,
-        }
+        FixedBitSet::from_blocks_and_len(data, len)
     }
 }
 
@@ -1457,12 +1450,7 @@ impl<'a> BitOr for &'a FixedBitSet {
             *data |= *block;
         }
         let len = core::cmp::max(self.len(), other.len());
-        let (data, capacity, _) = vec_into_parts(data);
-        FixedBitSet {
-            data,
-            capacity,
-            length: len,
-        }
+        FixedBitSet::from_blocks_and_len(data, len)
     }
 }
 
@@ -1493,12 +1481,7 @@ impl<'a> BitXor for &'a FixedBitSet {
             *data ^= *block;
         }
         let len = core::cmp::max(self.len(), other.len());
-        let (data, capacity, _) = vec_into_parts(data);
-        FixedBitSet {
-            data,
-            capacity,
-            length: len,
-        }
+        FixedBitSet::from_blocks_and_len(data, len)
     }
 }
 


### PR DESCRIPTION
The length in the Vec is redundant with the separate length in bits, making FixedBitset have some stack size overhead compared to a Vec. This PR removes that extra length, using the bit length to figure out the block length when necessary.

Ran benchmarks and saw no significant regressions.