### PR TITLE
Add support for AVX

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, nightly]
-        features: ["+avx2", "+sse2"]
+        features: ["+avx2", "+avx", "+sse2,+sse4.1", "+sse2"]
     env:
       RUSTFLAGS: "-C target-feature=${{matrix.features}} -D warnings"
     steps:

--- a/src/block/avx.rs
+++ b/src/block/avx.rs
@@ -6,17 +6,17 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, 
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
-pub struct Block(pub(super) __m256i);
+pub struct Block(pub(super) __m256d);
 
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_si256(self.0, self.0) == 1 }
+        unsafe { _mm256_testz_pd(self.0, self.0) == 1 }
     }
 
     #[inline]
     pub fn andnot(self, other: Self) -> Self {
-        Self(unsafe { _mm256_andnot_si256(other.0, self.0) })
+        unsafe { Self(_mm256_andnot_pd(other.0, self.0)) }
     }
 }
 
@@ -24,7 +24,7 @@ impl Not for Block {
     type Output = Block;
     #[inline]
     fn not(self) -> Self::Output {
-        unsafe { Self(_mm256_xor_si256(self.0, Self::ALL.0)) }
+        unsafe { Self(_mm256_xor_pd(self.0, Self::ALL.0)) }
     }
 }
 
@@ -32,7 +32,7 @@ impl BitAnd for Block {
     type Output = Block;
     #[inline]
     fn bitand(self, other: Self) -> Self::Output {
-        unsafe { Self(_mm256_and_si256(self.0, other.0)) }
+        unsafe { Self(_mm256_and_pd(self.0, other.0)) }
     }
 }
 
@@ -40,7 +40,7 @@ impl BitAndAssign for Block {
     #[inline]
     fn bitand_assign(&mut self, other: Self) {
         unsafe {
-            self.0 = _mm256_and_si256(self.0, other.0);
+            self.0 = _mm256_and_pd(self.0, other.0);
         }
     }
 }
@@ -49,7 +49,7 @@ impl BitOr for Block {
     type Output = Block;
     #[inline]
     fn bitor(self, other: Self) -> Self::Output {
-        unsafe { Self(_mm256_or_si256(self.0, other.0)) }
+        unsafe { Self(_mm256_or_pd(self.0, other.0)) }
     }
 }
 
@@ -57,7 +57,7 @@ impl BitOrAssign for Block {
     #[inline]
     fn bitor_assign(&mut self, other: Self) {
         unsafe {
-            self.0 = _mm256_or_si256(self.0, other.0);
+            self.0 = _mm256_or_pd(self.0, other.0);
         }
     }
 }
@@ -66,14 +66,14 @@ impl BitXor for Block {
     type Output = Block;
     #[inline]
     fn bitxor(self, other: Self) -> Self::Output {
-        unsafe { Self(_mm256_xor_si256(self.0, other.0)) }
+        unsafe { Self(_mm256_xor_pd(self.0, other.0)) }
     }
 }
 
 impl BitXorAssign for Block {
     #[inline]
     fn bitxor_assign(&mut self, other: Self) {
-        unsafe { self.0 = _mm256_xor_si256(self.0, other.0) }
+        unsafe { self.0 = _mm256_xor_pd(self.0, other.0) }
     }
 }
 
@@ -81,8 +81,8 @@ impl PartialEq for Block {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let neq = _mm256_xor_si256(self.0, other.0);
-            _mm256_testz_si256(neq, neq) == 1
+            let neq = _mm256_xor_pd(self.0, other.0);
+            _mm256_testz_pd(neq, neq) == 1
         }
     }
 }

--- a/src/block/avx.rs
+++ b/src/block/avx.rs
@@ -11,7 +11,7 @@ pub struct Block(pub(super) __m256d);
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_pd(self.0, Self::ALL.0) == 1 }
+        unsafe { _mm256_testz_pd(self.0, self.0) == 1 }
     }
 
     #[inline]
@@ -81,8 +81,8 @@ impl PartialEq for Block {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let neq = _mm256_xor_pd(self.0, other.0);
-            _mm256_testz_pd(neq, neq) == 1
+            let eq = _mm256_cmpeq_pd(self.0, other.0);
+            _mm256_movemask_pd(eq) == !(0i32)
         }
     }
 }

--- a/src/block/avx.rs
+++ b/src/block/avx.rs
@@ -11,7 +11,10 @@ pub struct Block(pub(super) __m256d);
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_pd(self.0, self.0) == 1 }
+        unsafe {
+            let value = core::mem::transmute(self);
+            _mm256_testz_si256(value, value) == 1
+        }
     }
 
     #[inline]
@@ -81,8 +84,9 @@ impl PartialEq for Block {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let eq = _mm256_cmpeq_pd(self.0, other.0);
-            _mm256_movemask_pd(eq) == !(0i32)
+            let new = _mm256_xor_pd(self.0, other.0);
+            let neq = core::mem::transmute(new);
+            _mm256_testz_si256(neq, neq) == 1
         }
     }
 }

--- a/src/block/avx.rs
+++ b/src/block/avx.rs
@@ -11,7 +11,7 @@ pub struct Block(pub(super) __m256d);
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_pd(self.0, self.0) == 1 }
+        unsafe { _mm256_testz_pd(self.0, Self::ALL.0) == 1 }
     }
 
     #[inline]

--- a/src/block/avx2.rs
+++ b/src/block/avx2.rs
@@ -11,7 +11,7 @@ pub struct Block(pub(super) __m256i);
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_si256(self.0, Self::ALL.0) == 1 }
+        unsafe { _mm256_testz_si256(self.0, self.0) == 1 }
     }
 
     #[inline]
@@ -81,8 +81,8 @@ impl PartialEq for Block {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let neq = _mm256_xor_si256(self.0, other.0);
-            _mm256_testz_si256(neq, neq) == 1
+            let eq = _mm256_cmpeq_si256(self.0, other.0);
+            _mm256_movemask_si256(eq) == !(0i32)
         }
     }
 }

--- a/src/block/avx2.rs
+++ b/src/block/avx2.rs
@@ -81,8 +81,8 @@ impl PartialEq for Block {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let eq = _mm256_cmpeq_si256(self.0, other.0);
-            _mm256_movemask_si256(eq) == !(0i32)
+            let neq = _mm256_xor_si256(self.0, other.0);
+            _mm256_testz_si256(neq, neq) == 1
         }
     }
 }

--- a/src/block/avx2.rs
+++ b/src/block/avx2.rs
@@ -11,7 +11,7 @@ pub struct Block(pub(super) __m256i);
 impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
-        unsafe { _mm256_testz_si256(self.0, self.0) == 1 }
+        unsafe { _mm256_testz_si256(self.0, Self::ALL.0) == 1 }
     }
 
     #[inline]

--- a/src/block/default.rs
+++ b/src/block/default.rs
@@ -2,26 +2,9 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, 
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(transparent)]
-pub struct Block(usize);
+pub struct Block(pub(super) usize);
 
 impl Block {
-    pub const USIZE_COUNT: usize = 1;
-    pub const NONE: Self = Block(0);
-    #[allow(dead_code)]
-    pub const ALL: Self = Block(!0);
-    pub const BITS: usize = core::mem::size_of::<Self>() * 8;
-
-    #[inline]
-    pub fn into_usize_array(self) -> [usize; Self::USIZE_COUNT] {
-        [self.0]
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
-        Self(array[0])
-    }
-
     #[inline]
     pub const fn is_empty(self) -> bool {
         self.0 == Self::NONE.0

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -51,9 +51,9 @@ mod avx2;
 #[cfg(all(not(target_arch = "wasm32"), target_feature = "avx2"))]
 pub use self::avx2::*;
 
-#[cfg(all(target_family = "wasm", target_feature="simd128"))]
+#[cfg(all(target_family = "wasm", target_feature = "simd128"))]
 mod wasm;
-#[cfg(all(target_arch = "wasm", target_feature="simd128"))]
+#[cfg(all(target_arch = "wasm", target_feature = "simd128"))]
 pub use self::wasm::*;
 
 impl Block {

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(dead_code)]
 
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -46,9 +46,15 @@ mod avx;
 ))]
 pub use self::avx::*;
 
-#[cfg(all(not(target_arch = "wasm32"), target_feature = "avx2"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
 mod avx2;
-#[cfg(all(not(target_arch = "wasm32"), target_feature = "avx2"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
 pub use self::avx2::*;
 
 #[cfg(all(target_family = "wasm", target_feature = "simd128"))]

--- a/src/block/sse2.rs
+++ b/src/block/sse2.rs
@@ -8,24 +8,9 @@ use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, 
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
-pub struct Block(__m128i);
+pub struct Block(pub(super) __m128i);
 
 impl Block {
-    pub const USIZE_COUNT: usize = core::mem::size_of::<Self>() / core::mem::size_of::<usize>();
-    pub const NONE: Self = Self::from_usize_array([0; Self::USIZE_COUNT]);
-    pub const ALL: Self = Self::from_usize_array([core::usize::MAX; Self::USIZE_COUNT]);
-    pub const BITS: usize = core::mem::size_of::<Self>() * 8;
-
-    #[inline]
-    pub fn into_usize_array(self) -> [usize; Self::USIZE_COUNT] {
-        unsafe { core::mem::transmute(self.0) }
-    }
-
-    #[inline]
-    pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
-        Self(unsafe { core::mem::transmute(array) })
-    }
-
     #[inline]
     pub fn is_empty(self) -> bool {
         #[cfg(not(target_feature = "sse4.1"))]

--- a/src/block/sse2.rs
+++ b/src/block/sse2.rs
@@ -19,7 +19,7 @@ impl Block {
         }
         #[cfg(target_feature = "sse4.1")]
         {
-            unsafe { _mm_test_all_zeros(self.0, Self::ALL.0) == 1 }
+            unsafe { _mm_test_all_zeros(self.0, self.0) == 1 }
         }
     }
 

--- a/src/block/wasm.rs
+++ b/src/block/wasm.rs
@@ -8,24 +8,9 @@ use core::{
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
-pub struct Block(v128);
+pub struct Block(pub(super) v128);
 
 impl Block {
-    pub const USIZE_COUNT: usize = core::mem::size_of::<Self>() / core::mem::size_of::<usize>();
-    pub const NONE: Self = Self::from_usize_array([0; Self::USIZE_COUNT]);
-    pub const ALL: Self = Self::from_usize_array([core::usize::MAX; Self::USIZE_COUNT]);
-    pub const BITS: usize = core::mem::size_of::<Self>() * 8;
-
-    #[inline]
-    pub fn into_usize_array(self) -> [usize; Self::USIZE_COUNT] {
-        unsafe { core::mem::transmute(self.0) }
-    }
-
-    #[inline]
-    pub const fn from_usize_array(array: [usize; Self::USIZE_COUNT]) -> Self {
-        Self(unsafe { core::mem::transmute(array) })
-    }
-
     #[inline]
     pub fn is_empty(self) -> bool {
         !v128_any_true(self.0)
@@ -33,7 +18,7 @@ impl Block {
 
     #[inline]
     pub fn andnot(self, other: Self) -> Self {
-        Self(unsafe { v128_andnot(self.0, other.0) })
+        Self(v128_andnot(self.0, other.0))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!  When SIMD is not available on the target, the crate will gracefully fallback to a default implementation.  It is intended to add support for other SIMD architectures
 //! once they appear in stable Rust.
 //!
-//! Currently only SSE2/AVX2 on x86/x86_64 and wasm32 SIMD are supported as this is what stable Rust supports.
+//! Currently only SSE2/AVX/AVX2 on x86/x86_64 and wasm32 SIMD are supported as this is what stable Rust supports.
 #![no_std]
 #![deny(clippy::undocumented_unsafe_blocks)]
 


### PR DESCRIPTION
This PR lowers the requirement for 256-bit wide vectors on x86/x86_64 platforms from AVX2 to AVX. #86 mistakenly assumes all of the operations are not available until AVX2, while in reality operations working on `__m256d` were viable from the start. The main difference is that the code doesn't really use the floating point operations on the type, so the two can be treated the same.

Performance-wise, benchmarks were run and there were zero shown deviations in performance between AVX and AVX2 other than some other incidental speedups in non-set/batch operations.

Used the opportunity to clean up the block directory and deduplicate repeated code and clean up some of the cfg attributes. Also added the new compilation configurations to CI.