### PR TITLE
Fix: Implement Send/Sync for FixedBitset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixedbitset"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["bluss"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixedbitset"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["bluss"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ Please read the [API documentation here](https://docs.rs/fixedbitset/)
 
 # Recent Changes
 
--   0.5.5
+-   0.5.6
+    - Fixed FixedBitset not implementing Send/Sync due to the stack size shrink.
+-   0.5.5 (yanked)
     - [#116](https://github.com/petgraph/fixedbitset/pull/116): Add functions for counting the results of a set operation (`union_count`, 
        `intersection_count`, `difference_count`, `symmetric_difference_count`) by @james7132.
     - [#118](https://github.com/petgraph/fixedbitset/pull/118): Shrink the stack size of FixedBitset. There should be zero stack size overhead
       compared to a Vec.
     - [#119](https://github.com/petgraph/fixedbitset/pull/119): Fix builds for wasm32.
+    - [#120](https://github.com/petgraph/fixedbitset/pull/119): Add more utility functions that were previously missing from the public interface:
+       `contains_any_in_range`, `contains_all_in_range`, `minimum`, `maximum`, `is_full`, `count_zeroes`, and `remove_range`.
     - [#121](https://github.com/petgraph/fixedbitset/pull/121): Add support for SIMD acceleration for AVX builds.
 -   0.5.4
     - [#112](https://github.com/petgraph/fixedbitset/pull/112): Fix undefined behavior in IntoOnes and setup testing with MIRI by @SkiFire13

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Please read the [API documentation here](https://docs.rs/fixedbitset/)
 
 # Recent Changes
 
+-   0.5.5
+    - [#116](https://github.com/petgraph/fixedbitset/pull/116): Add functions for counting the results of a set operation (`union_count`, 
+       `intersection_count`, `difference_count`, `symmetric_difference_count`) by @james7132.
+    - [#118](https://github.com/petgraph/fixedbitset/pull/118): Shrink the stack size of FixedBitset. There should be zero stack size overhead
+      compared to a Vec.
+    - [#119](https://github.com/petgraph/fixedbitset/pull/119): Fix builds for wasm32.
+    - [#121](https://github.com/petgraph/fixedbitset/pull/121): Add support for SIMD acceleration for AVX builds.
 -   0.5.4
     - [#112](https://github.com/petgraph/fixedbitset/pull/112): Fix undefined behavior in IntoOnes and setup testing with MIRI by @SkiFire13
 -   0.5.3 (yanked)

--- a/src/block/avx.rs
+++ b/src/block/avx.rs
@@ -12,7 +12,7 @@ impl Block {
     #[inline]
     pub fn is_empty(self) -> bool {
         unsafe {
-            let value = core::mem::transmute(self);
+            let value = _mm256_castpd_si256(self.0);
             _mm256_testz_si256(value, value) == 1
         }
     }
@@ -85,7 +85,7 @@ impl PartialEq for Block {
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             let new = _mm256_xor_pd(self.0, other.0);
-            let neq = core::mem::transmute(new);
+            let neq = _mm256_castpd_si256(new);
             _mm256_testz_si256(neq, neq) == 1
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub struct FixedBitSet {
 
 // SAFETY: FixedBitset contains no thread-local state and can be safely sent between threads
 unsafe impl Send for FixedBitSet {}
-// SAFETY: FixedBitset does not provide simultaneous unsynchronized mutable access to the 
+// SAFETY: FixedBitset does not provide simultaneous unsynchronized mutable access to the
 // underlying buffer.
 unsafe impl Sync for FixedBitSet {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,12 @@ pub struct FixedBitSet {
     pub(crate) length: usize,
 }
 
+// SAFETY: FixedBitset contains no thread-local state and can be safely sent between threads
+unsafe impl Send for FixedBitSet {}
+// SAFETY: FixedBitset does not provide simultaneous unsynchronized mutable access to the 
+// underlying buffer.
+unsafe impl Sync for FixedBitSet {}
+
 impl FixedBitSet {
     /// Create a new empty **FixedBitSet**.
     pub const fn new() -> Self {


### PR DESCRIPTION
#118 added a `NonNull` into FixedBitSet without adding a corresponding `Send`/`Sync` impl. This PR fixes that.