### PR TITLE
Further optimize Clone::clone_from

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1456,7 +1456,7 @@ impl Clone for FixedBitSet {
                 tail.fill(MaybeUninit::new(SimdBlock::NONE));
             }
             Ordering::Equal => me.copy_from_slice(them),
-            // The grow_uninit above ensures that self is at least as large as source.
+            // The grow_inner above ensures that self is at least as large as source.
             // so this branch is unreachable.
             Ordering::Less => {}
         }


### PR DESCRIPTION
Follow up to #127. This PR avoids a deallocation in the case where the backing store may need to grow.