### PR TITLE
Add FixedBitset::ones_with_capacity() to create all-ones bitset efficiently

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,7 +1003,7 @@ impl FixedBitSet {
     pub fn union_count(&self, other: &FixedBitSet) -> usize {
         let me = self.as_slice();
         let other = other.as_slice();
-        let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| (*x | *y)));
+        let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| *x | *y));
         match other.len().cmp(&me.len()) {
             Ordering::Greater => count + Self::batch_count_ones(other[me.len()..].iter().copied()),
             Ordering::Less => count + Self::batch_count_ones(me[other.len()..].iter().copied()),
@@ -1022,7 +1022,7 @@ impl FixedBitSet {
             self.as_slice()
                 .iter()
                 .zip(other.as_slice())
-                .map(|(x, y)| (*x & *y)),
+                .map(|(x, y)| *x & *y),
         )
     }
 
@@ -1037,7 +1037,7 @@ impl FixedBitSet {
             self.as_slice()
                 .iter()
                 .zip(other.as_slice().iter())
-                .map(|(x, y)| (*x & !*y)),
+                .map(|(x, y)| *x & !*y),
         ) + Self::batch_count_ones(self.as_slice().iter().skip(other.as_slice().len()).copied())
     }
 
@@ -1050,7 +1050,7 @@ impl FixedBitSet {
     pub fn symmetric_difference_count(&self, other: &FixedBitSet) -> usize {
         let me = self.as_slice();
         let other = other.as_slice();
-        let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| (*x ^ *y)));
+        let count = Self::batch_count_ones(me.iter().zip(other.iter()).map(|(x, y)| *x ^ *y));
         match other.len().cmp(&me.len()) {
             Ordering::Greater => count + Self::batch_count_ones(other[me.len()..].iter().copied()),
             Ordering::Less => count + Self::batch_count_ones(me[other.len()..].iter().copied()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,19 @@ impl FixedBitSet {
         }
     }
 
+    /// Create a new **FixedBitSet** with a specific number of bits,
+    /// all initially set.
+    ///
+    /// For example:
+    /// ```
+    /// let bs = fixedbitset::FixedBitSet::ones_with_capacity(10);
+    /// assert_eq!(bs.count_ones(..), 10);
+    /// assert_eq!(bs.len(), 10);
+    /// ```
+    pub fn ones_with_capacity(bits: usize) -> Self {
+        Self::with_capacity_and_blocks(bits, core::iter::repeat(!0))
+    }
+
     /// Grow capacity to **bits**, all new bits initialized to zero
     #[inline]
     pub fn grow(&mut self, bits: usize) {


### PR DESCRIPTION
Fixes #101

This PR includes:
* the new `FixedBitset::ones_with_capacity()` constructor
* optimization to `with_capacity_and_blocks()` to avoid double initialization
* minor warning fixes

Compared to the last version in #101, this implementation of `with_capacity_and_blocks()` makes sure to mask off unused bits in the last block to ensure `==` and `Hash` work correctly.